### PR TITLE
Support billable on time entry creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,11 +217,12 @@ func (session *Session) StartTimeEntry(description string) (TimeEntry, error) {
 }
 
 // StartTimeEntryForProject creates a new time entry for a specific project.
-func (session *Session) StartTimeEntryForProject(description string, projectID int) (TimeEntry, error) {
+func (session *Session) StartTimeEntryForProject(description string, projectID int, billable bool) (TimeEntry, error) {
 	data := map[string]interface{}{
 		"time_entry": map[string]interface{}{
 			"description":  description,
 			"pid":          projectID,
+			"billable":     billable,
 			"created_with": AppName,
 		},
 	}
@@ -269,6 +270,7 @@ func (session *Session) ContinueTimeEntry(timer TimeEntry, duronly bool) (TimeEn
 				"description":  timer.Description,
 				"pid":          timer.Pid,
 				"tid":          timer.Tid,
+				"billable":     timer.Billable,
 				"created_with": AppName,
 				"tags":         timer.Tags,
 				"duronly":      duronly,
@@ -290,6 +292,7 @@ func (session *Session) UnstopTimeEntry(timer TimeEntry) (newEntry TimeEntry, er
 			"description":  timer.Description,
 			"pid":          timer.Pid,
 			"tid":          timer.Tid,
+			"billable":     timer.Billable,
 			"created_with": AppName,
 			"tags":         timer.Tags,
 			"duronly":      timer.DurOnly,


### PR DESCRIPTION
Beside the additions in #3 I forgot to enable the API calls to really use this property to create the time entry.

I had to add an argument to the `StartTimeEntryForProject` so I could pass the `Billable` status.

In https://github.com/jason0x43/alfred-toggl/pull/45 I changed how this function is used so it's called with the correct signature.